### PR TITLE
feat: add similarity threshold for get_word_forms function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,34 @@ Some very timely examples :-P
 ```python
 >>> from word_forms.word_forms import get_word_forms
 >>> get_word_forms("president")
->>> {'n': {'presidents', 'presidentships', 'presidencies', 'presidentship', 'president', 'presidency'}, 
-     'a': {'presidential'}, 
-     'v': {'preside', 'presided', 'presiding', 'presides'}, 
+>>> {'n': {'presidents', 'presidentships', 'presidencies', 'presidentship', 'president', 'presidency'},
+     'a': {'presidential'},
+     'v': {'preside', 'presided', 'presiding', 'presides'},
      'r': {'presidentially'}}
 >>> get_word_forms("elect")
->>> {'n': {'elects', 'electives', 'electors', 'elect', 'eligibilities', 'electorates', 'eligibility', 'elector', 'election', 'elections', 'electorate', 'elective'}, 
-     'a': {'eligible', 'electoral', 'elective', 'elect'}, 
-     'v': {'electing', 'elects', 'elected', 'elect'}, 
+>>> {'n': {'elects', 'electives', 'electors', 'elect', 'eligibilities', 'electorates', 'eligibility', 'elector', 'election', 'elections', 'electorate', 'elective'},
+     'a': {'eligible', 'electoral', 'elective', 'elect'},
+     'v': {'electing', 'elects', 'elected', 'elect'},
      'r': set()}
 >>> get_word_forms("politician")
->>> {'n': {'politician', 'politics', 'politicians'}, 
-     'a': {'political'}, 
-     'v': set(), 
+>>> {'n': {'politician', 'politics', 'politicians'},
+     'a': {'political'},
+     'v': set(),
      'r': {'politically'}}
 >>> get_word_forms("am")
->>> {'n': {'being', 'beings'}, 
-     'a': set(), 
-     'v': {'was', 'be', "weren't", 'am', "wasn't", "aren't", 'being', 'were', 'is', "isn't", 'been', 'are', 'am not'}, 
+>>> {'n': {'being', 'beings'},
+     'a': set(),
+     'v': {'was', 'be', "weren't", 'am', "wasn't", "aren't", 'being', 'were', 'is', "isn't", 'been', 'are', 'am not'},
      'r': set()}
 >>> get_word_forms("ran")
->>> {'n': {'run', 'runniness', 'runner', 'runninesses', 'running', 'runners', 'runnings', 'runs'}, 
-     'a': {'running', 'runny'}, 
-     'v': {'running', 'run', 'ran', 'runs'}, 
+>>> {'n': {'run', 'runniness', 'runner', 'runninesses', 'running', 'runners', 'runnings', 'runs'},
+     'a': {'running', 'runny'},
+     'v': {'running', 'run', 'ran', 'runs'},
+     'r': set()}
+>>> get_word_forms('continent', 0.8) # with configurable similarity threshold
+>>> {'n': {'continents', 'continency', 'continences', 'continent', 'continencies', 'continence'},
+     'a': {'continental', 'continent'},
+     'v': set(),
      'r': set()}
 ```
 As you can see, the output is a dictionary with four keys. "r" stands for adverb, "a" for adjective, "n" for noun
@@ -47,20 +52,20 @@ Help can be obtained at any time by typing the following:
 ```
 
 ## Why?
-In Natural Language Processing and Search, one often needs to treat words like "run" and "ran", "love" and "lovable" 
-or "politician" and "politics" as the same word. This is usually done by algorithmically reducing each word into a 
-base word and then comparing the base words. The process is called Stemming. 
-For example, the [Porter Stemmer](http://text-processing.com/demo/stem/) reduces both "love" and "lovely" 
+In Natural Language Processing and Search, one often needs to treat words like "run" and "ran", "love" and "lovable"
+or "politician" and "politics" as the same word. This is usually done by algorithmically reducing each word into a
+base word and then comparing the base words. The process is called Stemming.
+For example, the [Porter Stemmer](http://text-processing.com/demo/stem/) reduces both "love" and "lovely"
 into the base word "love".
 
-Stemmers have several shortcomings. Firstly, the base word produced by the Stemmer is not always a valid English word. 
-For example, the Porter Stemmer reduces the word "operation" to "oper". Secondly, the Stemmers have a high false negative rate. 
-For example, "run" is reduced to "run" and "ran" is reduced to "ran". This happens because the Stemmers use a set of 
-rational rules for finding the base words, and as we all know, the English language does not always behave very rationally. 
+Stemmers have several shortcomings. Firstly, the base word produced by the Stemmer is not always a valid English word.
+For example, the Porter Stemmer reduces the word "operation" to "oper". Secondly, the Stemmers have a high false negative rate.
+For example, "run" is reduced to "run" and "ran" is reduced to "ran". This happens because the Stemmers use a set of
+rational rules for finding the base words, and as we all know, the English language does not always behave very rationally.
 
 Lemmatizers are more accurate than Stemmers because they produce a base form that is present in the dictionary (also called the Lemma). So the reduced word is always a valid English word. However, Lemmatizers also have false negatives because they are not very good at connecting words across different parts of speeches. The [WordNet Lemmatizer](http://textanalysisonline.com/nltk-wordnet-lemmatizer) included with NLTK fails at almost all such examples. "operations" is reduced to "operation"  and "operate" is reduced to "operate".
 
-Word Forms tries to solve this problem by finding all possible forms of a given English word. It can perform verb conjugations, connect noun forms to verb forms, adjective forms, adverb forms, plularize singular forms etc. 
+Word Forms tries to solve this problem by finding all possible forms of a given English word. It can perform verb conjugations, connect noun forms to verb forms, adjective forms, adverb forms, plularize singular forms etc.
 
 ## Bonus: A simple lemmatizer
 
@@ -108,18 +113,18 @@ git+git://github.com/gutfeeling/word_forms.git#egg=word_forms
 
 ## Maintainer
 
-Hi, I am Dibya and I maintain this repository. I would love to hear from you. Feel free to get in touch with me 
+Hi, I am Dibya and I maintain this repository. I would love to hear from you. Feel free to get in touch with me
 at dibyachakravorty@gmail.com.
 
 ## Contributor
 
-Tom Aarsen @CubieDev is a major contributor and is singlehandedly responsible for v2.0.0. 
+Tom Aarsen @CubieDev is a major contributor and is singlehandedly responsible for v2.0.0.
 
 ## Contributions
 
 Word Forms is not perfect. In particular, a couple of aspects can be improved.
 
 1. It sometimes generates non dictionary words like "runninesses" because the pluralization/singularization algorithm is
-not perfect. At the moment, I am using [inflect](https://pypi.python.org/pypi/inflect) for it. 
+not perfect. At the moment, I am using [inflect](https://pypi.python.org/pypi/inflect) for it.
 
 If you like this package, feel free to contribute. Your pull requests are most welcome.

--- a/word_forms/word_forms.py
+++ b/word_forms/word_forms.py
@@ -47,7 +47,7 @@ def get_related_lemmas(word):
     return get_related_lemmas_rec(word, [])
 
 
-def get_related_lemmas_rec(word, known_lemmas):
+def get_related_lemmas_rec(word, known_lemmas, similarity_threshold):
     # Turn string word into list of Lemma objects
     all_lemmas_for_this_word = [
         lemma
@@ -64,17 +64,18 @@ def get_related_lemmas_rec(word, known_lemmas):
         for new_lemma in lemma.derivationally_related_forms() + lemma.pertainyms():
             if (
                 not belongs(new_lemma, known_lemmas)
-                and ratio(word, new_lemma.name()) > 0.4
+                and ratio(word, new_lemma.name()) > similarity_threshold
             ):
-                get_related_lemmas_rec(new_lemma.name(), known_lemmas)
+                get_related_lemmas_rec(new_lemma.name(), known_lemmas, similarity_threshold)
     # Return the known lemmas
     return known_lemmas
 
 
-def get_word_forms(word):
+def get_word_forms(word, similarity_threshold=0.4):
     """
     args
         word : a word e.g "love"
+        similarity_threshold: minimum levenshtein ratio e.g 0.5 (default: 0.4)
 
     returns the related word forms corresponding to the input word. the output
     is a dictionary with four keys "n" (noun), "a" (adjective), "v" (verb)
@@ -92,7 +93,7 @@ def get_word_forms(word):
     }
     related_lemmas = []
     for lemmatized_word in words:
-        get_related_lemmas_rec(lemmatized_word, related_lemmas)
+        get_related_lemmas_rec(lemmatized_word, related_lemmas, similarity_threshold)
     related_words_dict = {"n": set(), "a": set(), "v": set(), "r": set()}
     for lemma in related_lemmas:
         pos = lemma.synset().pos()


### PR DESCRIPTION
Sometimes, the get_word_forms function returns outlandish results:
```
>>> get_word_forms("continent")
{'n': {'contentments', 'continent', 'containment', 'continence', 'continency', 'continents', 'continences', 'continencies', 'container', 'content', 'containments', 'contents', 'contentment', 'containers'}, 'a': {'continent', 'continental', 'content'}, 'v': {'containerized', 'containerize', 'containerizing', 'contains', 'containing', 'contain', 'contented', 'containerizes', 'contenting', 'contents', 'content', 'contained', 'containerise'}, 'r': set()}
```
Word forms such as "container" or "content" may not really make sense here for a user's purpose.
 
This pull request allows users to set a custom similarity threshold to configure the similarity of the results obtained from the `get_word_forms` function as an easy way to filter out (or perhaps, include more) results.

```
>>> get_word_forms('continent', 0.8)
{'n': {'continents', 'continent', 'continences', 'continence', 'continencies', 'continency'}, 'a': {'continent', 'continental'}, 'v': set(), 'r': set()}
```

The default behaviour of the library remains unchanged. If a user does not specify the similarity threshold, a default value of 0.4, which was hardcoded in the code till now, is used.

