### PR TITLE
Bugfix: Update conjugated verb sets instead of overwriting them

### DIFF
--- a/word_forms/constants.py
+++ b/word_forms/constants.py
@@ -1,4 +1,5 @@
 from difflib import get_close_matches
+from collections import defaultdict
 from pathlib import Path
 
 try:
@@ -16,22 +17,26 @@ ALL_WORDNET_WORDS = set(words.words())
 
 
 class Verb(object):
-    def __init__(self, verbs):
-        self.verbs = verbs
+    def __init__(self, verbs=None):
+        self.verbs = verbs if verbs else set()
 
     def __repr__(self):
         return "Verbs" + str(self.verbs)
+
+    def update(self, verbs):
+        self.verbs.update(verbs)
 
 
 verbs_fh = open(str(Path(__file__).parent.absolute() / "en-verbs.txt"))
 lines = verbs_fh.readlines()
 verbs_fh.close()
-CONJUGATED_VERB_DICT = {}
+
+CONJUGATED_VERB_DICT = defaultdict(Verb)
 for line in lines:
     if line[0] != ";":
-        verb_obj = Verb({string for string in line.strip().split(",") if string != ""})
-        for verb in verb_obj.verbs:
-            CONJUGATED_VERB_DICT[verb] = verb_obj
+        verbs = {string for string in line.strip().split(",") if string != ""}
+        for verb in verbs:
+            CONJUGATED_VERB_DICT[verb].update(verbs)
 
 ADJECTIVE_TO_ADVERB = {"good" : "well", "fast" : "fast", "hard" : "hard",
                        "late" : "late", "early" : "early", "daily" : "daily",


### PR DESCRIPTION
Currently, while collecting the CONJUGATED_VERB_DICT from en-verbs.txt, sets of conjugated verbs for a given verb are overwritten if the given verb exists multiple times in the en-verbs.txt file.

An example of this is `'number'`. It appears on 1288 as:
number,,,numbers,,numbering,,,,,numbered,numbered,,,,,,,,,,,,
and on line 7614 as:
number,,,numbs,,numbing,,,,,numbed,numbed,,,,,,,,,,,,

So, while collecting the verb conjugations for `number`, only the ones on line 7614 will be kept, thus, overwriting the (arguably) correct conjugations.

This PR updates the behavior to update the pre-existing set instead of overwriting it. This way we keep conjugations from both lines.